### PR TITLE
Add full support of Texas Holdem No Limit game

### DIFF
--- a/agents/prompts.py
+++ b/agents/prompts.py
@@ -260,3 +260,40 @@ MESSAGE: [amused] The odds of this working get better every orbit
 INTENT: Create doubt about bluffing frequency
 CONFIDENCE: 8
 """
+
+
+# Add a new prompt for Texas Holdem specific decision making
+# Variables:
+# - strategy_style: Agent's current strategy style
+# - game_state: Current game situation including cards, bets, etc.
+# - hand_eval: Current hand evaluation
+# - community_cards: Community cards on the table
+TEXAS_HOLDEM_DECISION_PROMPT = """You are a {strategy_style} Texas Holdem poker player.
+
+Current game state:
+{game_state}
+
+Hand Evaluation:
+{hand_eval}
+
+Community Cards:
+{community_cards}
+
+You must respond with EXACTLY ONE of these formats:
+1. DECISION: fold
+2. DECISION: call
+3. DECISION: raise NUMBER
+
+Examples of valid responses:
+DECISION: fold
+DECISION: call
+DECISION: raise 200
+
+Rules:
+- Use ONLY the exact formats above
+- For raise, include only a number (no words/explanations)
+- Do not include any other text or explanations
+- NUMBER must be a positive integer
+
+What is your decision?
+"""

--- a/agents/strategy_planner.py
+++ b/agents/strategy_planner.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-#! move to config
 DEFAULT_PLAN_DURATION = 30.0
 REPLAN_STACK_THRESHOLD = 100
 
@@ -56,6 +55,7 @@ class StrategyPlanner:
         player: "Player",
         game: "Game",
         hand_eval: Optional[HandEvaluation] = None,
+        community_cards: Optional[list] = None,
     ) -> None:
         """Generate or update the agent's strategic plan based on current game state."""
         try:
@@ -70,6 +70,7 @@ class StrategyPlanner:
                 player=player,
                 game_state=game.get_state(),
                 hand_eval=hand_eval,
+                community_cards=community_cards,
             )
             self.current_plan = self._create_plan_from_response(plan_data)
             logger.info(

--- a/config.py
+++ b/config.py
@@ -2,7 +2,6 @@ from typing import Dict
 
 
 class GameConfig:
-    #! how is this different with game.config.py?
     """Configuration for poker game settings."""
 
     # Database settings
@@ -26,6 +25,14 @@ class GameConfig:
     # Betting limits
     MIN_RAISE: int = 20
     MAX_RAISE_MULTIPLIER: int = 4  # max raise = current_bet * multiplier
+
+    # Texas Holdem specific settings
+    TEXAS_HOLDEM_STARTING_CHIPS: int = 2000
+    TEXAS_HOLDEM_SMALL_BLIND: int = 25
+    TEXAS_HOLDEM_BIG_BLIND: int = 50
+    TEXAS_HOLDEM_ANTE: int = 5
+    TEXAS_HOLDEM_MIN_RAISE: int = 50
+    TEXAS_HOLDEM_MAX_RAISE_MULTIPLIER: int = 5
 
     class Config:
         env_file = ".env"

--- a/data/states/round_state.py
+++ b/data/states/round_state.py
@@ -45,11 +45,21 @@ class RoundState(BaseModel):
         return v
 
     @classmethod
-    def new_round(cls, round_number: int) -> "RoundState":
+    def new_round(cls, round_number: int, game_type: str) -> "RoundState":
         """Create a new round state for the start of a hand."""
-        return cls(
-            phase=RoundPhase.PREFLOP,
-            current_bet=0,
-            round_number=round_number,
-            raise_count=0,
-        )
+        if game_type == "texas-holdem":
+            return cls(
+                phase=RoundPhase.PREFLOP,
+                current_bet=0,
+                round_number=round_number,
+                raise_count=0,
+            )
+        elif game_type == "5-card-draw":
+            return cls(
+                phase=RoundPhase.PRE_DRAW,
+                current_bet=0,
+                round_number=round_number,
+                raise_count=0,
+            )
+        else:
+            raise ValueError(f"Unsupported game type: {game_type}")

--- a/game/evaluator.py
+++ b/game/evaluator.py
@@ -157,3 +157,48 @@ def evaluate_hand(cards: List[Card]) -> HandEvaluation:
 
     else:  # High card
         return (10, ranks, f"High Card, {ranks[0]}")
+
+
+def evaluate_texas_holdem_hand(hole_cards: List[Card], community_cards: List[Card]) -> HandEvaluation:
+    """
+    Evaluate a Texas Hold'em hand and return its ranking, tiebreakers, and description.
+
+    Args:
+        hole_cards (List[Card]): A list of exactly 2 Card objects representing the player's hole cards.
+        community_cards (List[Card]): A list of exactly 5 Card objects representing the community cards.
+
+    Returns:
+        HandEvaluation: A named tuple containing:
+            - int: Hand rank from 1-10 (1 being best, 10 being worst)
+            - List[int]: Tiebreaker values in descending order of importance
+            - str: Human readable description of the hand
+
+    Raises:
+        ValueError: If the hole cards or community cards don't contain the correct number of cards
+
+    Example:
+        >>> hole_cards = [Card('A', '♠'), Card('K', '♠')]
+        >>> community_cards = [Card('Q', '♠'), Card('J', '♠'), Card('10', '♠'), Card('2', '♦'), Card('3', '♣')]
+        >>> evaluate_texas_holdem_hand(hole_cards, community_cards)
+        (1, [14, 13, 12, 11, 10], 'Royal Flush')
+    """
+    if len(hole_cards) != 2:
+        raise ValueError("Hole cards must contain exactly 2 cards")
+    if len(community_cards) != 5:
+        raise ValueError("Community cards must contain exactly 5 cards")
+
+    # Combine hole cards and community cards
+    all_cards = hole_cards + community_cards
+
+    # Generate all possible 5-card combinations
+    from itertools import combinations
+    possible_hands = combinations(all_cards, 5)
+
+    # Evaluate each combination and keep the best one
+    best_hand = None
+    for hand in possible_hands:
+        hand_evaluation = evaluate_hand(list(hand))
+        if not best_hand or hand_evaluation.rank < best_hand.rank:
+            best_hand = hand_evaluation
+
+    return best_hand

--- a/game/player.py
+++ b/game/player.py
@@ -1,7 +1,10 @@
 import logging
+from typing import List
 
 from data.states.player_state import PlayerState
 from data.types.player_types import PlayerPosition
+from game.evaluator import evaluate_texas_holdem_hand, HandEvaluation
+from game.card import Card
 
 from .hand import Hand
 
@@ -156,3 +159,38 @@ class Player:
     def position(self, value: PlayerPosition):
         """Set the player's position at the table."""
         self._position = value
+
+    def take_action(self, action: str, amount: int = 0) -> None:
+        """
+        Perform a player action (fold, call, raise) with optional bet amount.
+
+        Args:
+            action (str): The action to perform ('fold', 'call', 'raise')
+            amount (int, optional): The amount to bet if raising. Defaults to 0.
+
+        Raises:
+            ValueError: If the action is invalid or amount is negative
+        """
+        if action not in ["fold", "call", "raise"]:
+            raise ValueError(f"Invalid action: {action}")
+        if amount < 0:
+            raise ValueError("Amount cannot be negative")
+
+        if action == "fold":
+            self.fold()
+        elif action == "call":
+            self.place_bet(amount)
+        elif action == "raise":
+            self.place_bet(amount)
+
+    def evaluate_hand(self, community_cards: List[Card]) -> HandEvaluation:
+        """
+        Evaluate the player's hand in Texas Hold'em using community cards.
+
+        Args:
+            community_cards (List[Card]): The community cards on the table
+
+        Returns:
+            HandEvaluation: The evaluation of the player's best hand
+        """
+        return evaluate_texas_holdem_hand(self.hand.cards, community_cards)


### PR DESCRIPTION
Add support for Texas Holdem No Limit game to the existing poker game implementation.

* **game/game.py**
  - Modify `AgenticPoker` class to handle Texas Holdem specific rules and logic.
  - Update `start_game` and `start_round` methods to include Texas Holdem specific logic.
  - Add methods to handle Texas Holdem betting rounds, hand evaluation, and player actions.
  - Add `_deal_community_cards` and `_handle_showdown` methods for Texas Holdem.

* **game/evaluator.py**
  - Add `evaluate_texas_holdem_hand` function to evaluate Texas Holdem hands.

* **game/player.py**
  - Add `take_action` method to handle player actions (fold, call, raise).
  - Add `evaluate_hand` method to evaluate player's hand in Texas Holdem using community cards.

* **agents/prompts.py**
  - Add Texas Holdem specific prompts for the LLM agent.

* **agents/strategy_planner.py**
  - Update `plan_strategy` method to include Texas Holdem specific logic.

* **data/states/game_state.py**
  - Add `community_cards` attribute to `GameState` class.
  - Update `from_game` method to include Texas Holdem specific state logic.

* **data/states/round_state.py**
  - Modify `new_round` method to handle Texas Holdem specific round state management.

* **config.py**
  - Add Texas Holdem specific configuration options.

